### PR TITLE
Update debugging relevant to kernel panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Disables `/lib/systemd/coredump.conf.d/disable-coredumps.conf` by package
 `/etc/systemd/coredump.conf.d/disable-coredumps.conf` to `/dev/null`.
 `debian/debug-misc.links`
 
-Disables `panic-on-oops`, `remove-system.map` by package `security-misc`.
+Disables `panic-on-oops`,`panic-on-warn`, `remove-system.map` by package `security-misc`.
 
 `config-package-dev` `hide` `/etc/sysctl.d/30_silent-kernel-printk.conf` which
 kernel.printk to default as if security-misc would not have lowered verbosity.

--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -9,7 +9,7 @@
 #kernel.panic=0
 kernel.panic_on_oops=0
 kernel.panic_on_warn=0
-#kernel.oops_limit=10000
+#kernel.oops_limit=0
 #kernel.warn_limit=0
 
 kernel.sysrq=1

--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -6,7 +6,7 @@
 #### category debugging
 #### description
 
-#kerne.panic=60
+#kernel.panic=0
 kernel.panic_on_oops=0
 kernel.panic_on_warn=0
 #kernel.oops_limit=10000

--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -6,7 +6,12 @@
 #### category debugging
 #### description
 
+#kerne.panic=60
 kernel.panic_on_oops=0
+kernel.panic_on_warn=0
+#kernel.oops_limit=10000
+#kernel.warn_limit=0
+
 kernel.sysrq=1
 
 fs.suid_dumpable=1


### PR DESCRIPTION
This pull request addresses https://github.com/Kicksecure/security-misc/pull/268#issuecomment-2317112703.

## Changes

Disable kernel panics on warnings via:
`sysctl kernel.panic_on_warn=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it