### PR TITLE
Update debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ Undo debugging related `sysctl` settings by package `security-misc`.
 
 Enables persistent systemd journal log.
 
-Disables `/lib/systemd/coredump.conf.d/disable-coredumps.conf` by package
-`security-misc` by creating a symlink from
-`/etc/systemd/coredump.conf.d/disable-coredumps.conf` to `/dev/null`.
-`debian/debug-misc.links`
+ Disables `/usr/lib/systemd/coredump.conf.d/30_security-misc.conf` by package
+`security-misc` using `debian/debug-misc.links` by creating a symlink from
+`/etc/systemd/coredump.conf.d/30_security-misc.conf` to `/dev/null`.
 
 Disables `panic-on-oops`, `remove-system.map` by package `security-misc`.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Enables miscellaneous debug settings #
 
 Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file,
-that removes `quiet`, `loglevel=0` and `debugfs=off` from the
-`GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to the kernel
-boot parameter to enable verbose output during the initial ramdisk boot
-phase.
+that removes `quiet`, `loglevel=0`, `debugfs=off`, and `efi_pstore.pstore_disable=1`
+from the `GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to
+the kernel boot parameter to enable verbose output during the initial
+ramdisk boot phase.
 
 Undo debugging related `sysctl` settings by package `security-misc`.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Enables persistent systemd journal log.
 `security-misc` using `debian/debug-misc.links` by creating a symlink from
 `/etc/systemd/coredump.conf.d/30_security-misc.conf` to `/dev/null`.
 
+Disables `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf` by package
+`security-misc` using `debian/debug-misc.links` by creating a symlink from
+`/etc/systemd/pstore.conf.d/30_security-misc.conf` to `/dev/null`.
+
 Disables `panic-on-oops`, `remove-system.map` by package `security-misc`.
 
 `config-package-dev` `hide` `/etc/sysctl.d/30_silent-kernel-printk.conf` which

--- a/debian/control
+++ b/debian/control
@@ -28,10 +28,9 @@ Description: Enables miscellaneous debug settings
  .
  Enables persistent systemd journal log.
  .
- Disables `/lib/systemd/coredump.conf.d/disable-coredumps.conf` by package
- `security-misc` by creating a symlink from
- `/etc/systemd/coredump.conf.d/disable-coredumps.conf` to `/dev/null`.
- `debian/debug-misc.links`
+ Disables `/usr/lib/systemd/coredump.conf.d/30_security-misc.conf` by package
+`security-misc` using `debian/debug-misc.links` by creating a symlink from
+`/etc/systemd/coredump.conf.d/30_security-misc.conf` to `/dev/null`.
  .
  Disables `panic-on-oops`, `remove-system.map` by package `security-misc`.
  .

--- a/debian/control
+++ b/debian/control
@@ -19,10 +19,10 @@ Suggests: systemd-coredump, serial-console-enable
 Replaces: grub-output-verbose
 Description: Enables miscellaneous debug settings
  Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file,
- that removes `quiet`, `loglevel=0` and `debugfs=off` from the
- `GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to the kernel
- boot parameter to enable verbose output during the initial ramdisk boot
- phase.
+that removes `quiet`, `loglevel=0`, `debugfs=off`, and `efi_pstore.pstore_disable=1`
+from the `GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to
+the kernel boot parameter to enable verbose output during the initial
+ramdisk boot phase.
  .
  Undo debugging related `sysctl` settings by package `security-misc`.
  .

--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,10 @@ Description: Enables miscellaneous debug settings
 `security-misc` using `debian/debug-misc.links` by creating a symlink from
 `/etc/systemd/coredump.conf.d/30_security-misc.conf` to `/dev/null`.
  .
+ Disables `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf` by package
+`security-misc` using `debian/debug-misc.links` by creating a symlink from
+`/etc/systemd/pstore.conf.d/30_security-misc.conf` to `/dev/null`.
+ .
  Disables `panic-on-oops`, `remove-system.map` by package `security-misc`.
  .
  `config-package-dev` `hide` `/etc/sysctl.d/30_silent-kernel-printk.conf` which

--- a/debian/debug-misc.links
+++ b/debian/debug-misc.links
@@ -1,6 +1,6 @@
 ## Copyright (C) 2019 - 2025 ENCRYPTED SUPPORT LLC <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Disable /lib/systemd/coredump.conf.d/30_security-misc.conf by
+## Disable /usr/lib/systemd/coredump.conf.d/30_security-misc.conf by
 ## package security-misc.
 /dev/null /etc/systemd/coredump.conf.d/30_security-misc.conf

--- a/debian/debug-misc.links
+++ b/debian/debug-misc.links
@@ -4,3 +4,7 @@
 ## Disable /usr/lib/systemd/coredump.conf.d/30_security-misc.conf by
 ## package security-misc.
 /dev/null /etc/systemd/coredump.conf.d/30_security-misc.conf
+
+## Disable /usr/lib/systemd/pstore.conf.d/30_security-misc.conf by
+## package security-misc.
+/dev/null /etc/systemd/pstore.conf.d/30_security-misc.conf

--- a/etc/default/grub.d/45_debug-misc.cfg
+++ b/etc/default/grub.d/45_debug-misc.cfg
@@ -16,6 +16,8 @@ GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/loglev
 
 GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/debugfs=off//g')" || echo "$0: Removing 'debugfs=off' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
 
+GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/efi_pstore.pstore_disable=1//g')" || echo "$0: Removing 'efi_pstore.pstore_disable=1' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
+
 ## initramfs-tools
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debug=vc"
 


### PR DESCRIPTION
This pull request addresses https://github.com/Kicksecure/security-misc/pull/304#issuecomment-2798249239.

## Changes

Update enabling coredumps documentation for clarity.

Disables `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf` by package `security-misc` using `debian/debug-misc.links` by creating a symlink from `/etc/systemd/pstore.conf.d/30_security-misc.conf` to `/dev/null`.

Removes `efi_pstore.pstore_disable=1` boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it