### PR TITLE
Update debugging relevant to kernel parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Enables miscellaneous debug settings #
 
-Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file,
-that removes `quiet`, `loglevel=0`, `debugfs=off`,
-`efi_pstore.pstore_disable=1`, and `erst_disable` from the
-`GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to the
+Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file.
+This removes `quiet`, `loglevel=0`, and `rhgb` from the
+`GRUB_CMDLINE_LINUX_DEFAULT` variable It also removes `debugfs=off`,
+`efi_pstore.pstore_disable=1`,and `erst_disable` from the
+`GRUB_CMDLINE_LINUX` variable. Finally, it adds `debug=vc` to the
 kernel boot parameter to enable verbose output during the initial
 ramdisk boot phase.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file.
 This removes `quiet`, `loglevel=0`, and `rhgb` from the
 `GRUB_CMDLINE_LINUX_DEFAULT` variable. It also removes `debugfs=off`,
-`efi_pstore.pstore_disable=1`,and `erst_disable` from the
+`efi_pstore.pstore_disable=1`, and `erst_disable` from the
 `GRUB_CMDLINE_LINUX` variable. Finally, it adds `debug=vc` to the
-the `GRUB_CMDLINE_LINUX` variable to enable verbose output during the
+`GRUB_CMDLINE_LINUX` variable to enable verbose output during the
 initial ramdisk boot phase.
 
 Undo debugging related `sysctl` settings by package `security-misc`.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file.
 This removes `quiet`, `loglevel=0`, and `rhgb` from the
-`GRUB_CMDLINE_LINUX_DEFAULT` variable It also removes `debugfs=off`,
+`GRUB_CMDLINE_LINUX_DEFAULT` variable. It also removes `debugfs=off`,
 `efi_pstore.pstore_disable=1`,and `erst_disable` from the
 `GRUB_CMDLINE_LINUX` variable. Finally, it adds `debug=vc` to the
-kernel boot parameter to enable verbose output during the initial
-ramdisk boot phase.
+the `GRUB_CMDLINE_LINUX` variable to enable verbose output during the
+initial ramdisk boot phase.
 
 Undo debugging related `sysctl` settings by package `security-misc`.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Enables miscellaneous debug settings #
 
 Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file,
-that removes `quiet`, `loglevel=0`, `debugfs=off`, and
-`efi_pstore.pstore_disable=1` from the `GRUB_CMDLINE_LINUX_DEFAULT`
-variable and adds `debug=vc` to the kernel boot parameter to enable
-verbose output during the initial ramdisk boot phase.
+that removes `quiet`, `loglevel=0`, `debugfs=off`,
+`efi_pstore.pstore_disable=1`, and `erst_disable` from the
+`GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to the
+kernel boot parameter to enable verbose output during the initial
+ramdisk boot phase.
 
 Undo debugging related `sysctl` settings by package `security-misc`.
 

--- a/debian/control
+++ b/debian/control
@@ -18,10 +18,11 @@ Depends: ${misc:Depends}
 Suggests: systemd-coredump, serial-console-enable
 Replaces: grub-output-verbose
 Description: Enables miscellaneous debug settings
- Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file,
- that removes `quiet`, `loglevel=0`, `debugfs=off`,
- `efi_pstore.pstore_disable=1`, and `erst_disable` from the
- `GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to the
+ Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file.
+ This removes `quiet`, `loglevel=0`, and `rhgb` from the
+ `GRUB_CMDLINE_LINUX_DEFAULT` variable It also removes `debugfs=off`,
+ `efi_pstore.pstore_disable=1`,and `erst_disable` from the
+ `GRUB_CMDLINE_LINUX` variable. Finally, it adds `debug=vc` to the
  kernel boot parameter to enable verbose output during the initial
  ramdisk boot phase.
  .

--- a/debian/control
+++ b/debian/control
@@ -19,10 +19,11 @@ Suggests: systemd-coredump, serial-console-enable
 Replaces: grub-output-verbose
 Description: Enables miscellaneous debug settings
  Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file,
- that removes `quiet`, `loglevel=0`, `debugfs=off`, and
- `efi_pstore.pstore_disable=1` from the `GRUB_CMDLINE_LINUX_DEFAULT`
- variable and adds `debug=vc` to the kernel boot parameter to enable
- verbose output during the initial ramdisk boot phase.
+ that removes `quiet`, `loglevel=0`, `debugfs=off`,
+ `efi_pstore.pstore_disable=1`, and `erst_disable` from the
+ `GRUB_CMDLINE_LINUX_DEFAULT` variable and adds `debug=vc` to the
+ kernel boot parameter to enable verbose output during the initial
+ ramdisk boot phase.
  .
  Undo debugging related `sysctl` settings by package `security-misc`.
  .

--- a/debian/control
+++ b/debian/control
@@ -20,11 +20,11 @@ Replaces: grub-output-verbose
 Description: Enables miscellaneous debug settings
  Ships a `/etc/default/grub.d/45_debug-misc.cfg` configuration file.
  This removes `quiet`, `loglevel=0`, and `rhgb` from the
- `GRUB_CMDLINE_LINUX_DEFAULT` variable It also removes `debugfs=off`,
+ `GRUB_CMDLINE_LINUX_DEFAULT` variable. It also removes `debugfs=off`,
  `efi_pstore.pstore_disable=1`,and `erst_disable` from the
  `GRUB_CMDLINE_LINUX` variable. Finally, it adds `debug=vc` to the
- kernel boot parameter to enable verbose output during the initial
- ramdisk boot phase.
+ the `GRUB_CMDLINE_LINUX` variable to enable verbose output during the
+ initial ramdisk boot phase.
  .
  Undo debugging related `sysctl` settings by package `security-misc`.
  .

--- a/etc/default/grub.d/45_debug-misc.cfg
+++ b/etc/default/grub.d/45_debug-misc.cfg
@@ -10,15 +10,15 @@
 
 GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/quiet//g')" || echo "$0: Removing 'quiet' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/rhgb//g')" || echo "$0: Removing 'rhgb' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
-
 GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/loglevel=0//g')" || echo "$0: Removing 'loglevel=0' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/debugfs=off//g')" || echo "$0: Removing 'debugfs=off' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
+GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/rhgb//g')" || echo "$0: Removing 'rhgb' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/efi_pstore.pstore_disable=1//g')" || echo "$0: Removing 'efi_pstore.pstore_disable=1' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
+GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/debugfs=off//g')" || echo "$0: Removing 'debugfs=off' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/erst_disable//g')" || echo "$0: Removing 'erst_disable' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
+GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/efi_pstore.pstore_disable=1//g')" || echo "$0: Removing 'efi_pstore.pstore_disable=1' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
+
+GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/erst_disable//g')" || echo "$0: Removing 'erst_disable' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
 
 ## initramfs-tools
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debug=vc"

--- a/etc/default/grub.d/45_debug-misc.cfg
+++ b/etc/default/grub.d/45_debug-misc.cfg
@@ -18,6 +18,8 @@ GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/debugf
 
 GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/efi_pstore.pstore_disable=1//g')" || echo "$0: Removing 'efi_pstore.pstore_disable=1' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
 
+GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/erst_disable//g')" || echo "$0: Removing 'erst_disable' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
+
 ## initramfs-tools
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debug=vc"
 

--- a/etc/default/grub.d/45_debug-misc.cfg
+++ b/etc/default/grub.d/45_debug-misc.cfg
@@ -14,11 +14,11 @@ GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/loglev
 
 GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX_DEFAULT" | sed 's/rhgb//g')" || echo "$0: Removing 'rhgb' from GRUB_CMDLINE_LINUX_DEFAULT failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/debugfs=off//g')" || echo "$0: Removing 'debugfs=off' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
+GRUB_CMDLINE_LINUX="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/debugfs=off//g')" || echo "$0: Removing 'debugfs=off' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/efi_pstore.pstore_disable=1//g')" || echo "$0: Removing 'efi_pstore.pstore_disable=1' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
+GRUB_CMDLINE_LINUX="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/efi_pstore.pstore_disable=1//g')" || echo "$0: Removing 'efi_pstore.pstore_disable=1' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
 
-GRUB_CMDLINE_LINUX_DEFAULT="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/erst_disable//g')" || echo "$0: Removing 'erst_disable' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
+GRUB_CMDLINE_LINUX="$(echo "$GRUB_CMDLINE_LINUX" | sed 's/erst_disable//g')" || echo "$0: Removing 'erst_disable' from GRUB_CMDLINE_LINUX failed! Please report this bug!" >&2
 
 ## initramfs-tools
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debug=vc"


### PR DESCRIPTION
This pull request reverts https://github.com/Kicksecure/security-misc/pull/306 and corrects a few other reversions.

## Changes

Removes the `erst_disable` kernel parameter.

Provides corrections to reverting `debugfs=off` and `efi_pstore.pstore_disable=1`.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it