### PR TITLE
Upgrade `sysctl` settings on kernel panics

### DIFF
--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -6,7 +6,7 @@
 #### category debugging
 #### description
 
-#kernel.panic=0
+kernel.panic=0
 kernel.oops_limit=0
 kernel.warn_limit=0
 

--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -6,18 +6,21 @@
 #### category debugging
 #### description
 
-kernel.panic=0
+kernel.kptr_restrict=0
+
+kernel.sysrq=1
+
 kernel.oops_limit=0
 kernel.warn_limit=0
 
-kernel.sysrq=1
+kernel.panic=0
+
+kernel.yama.ptrace_scope=0
+
+kernel.core_pattern=core
 
 fs.suid_dumpable=1
 #fs.suid_dumpable=2
 #fs.suid_dumpable=3
-
-kernel.yama.ptrace_scope=0
-kernel.kptr_restrict=0
-kernel.core_pattern=core
 
 #### meta end

--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -7,10 +7,8 @@
 #### description
 
 #kernel.panic=0
-kernel.panic_on_oops=0
-kernel.panic_on_warn=0
-#kernel.oops_limit=0
-#kernel.warn_limit=0
+kernel.oops_limit=0
+kernel.warn_limit=0
 
 kernel.sysrq=1
 


### PR DESCRIPTION
This draft pull request reverts the the upgraded `sysctl` settings in https://github.com/Kicksecure/security-misc/pull/313.

The changes provide equivalent functionality in disabling kernel panics on both oopses and warning.

Note:
Should ONLY be considered after upgrading to Debian 13 (trixie). Changes have been submitted early to facilitate quicker feedback and review which would ideally enable more swift merging.

## Changes

Redundant `sysctl` settings are removed: `kernel.panic_on_oops=0` and `kernel.panic_on_warn=0`

Upgraded `sysctl` settings are enabled: `kernel.oops_limit=0` and `kernel.warn_limit=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it