### PR TITLE
Add CD-ROM/DVD debugging settings

### DIFF
--- a/etc/sysctl.d/40_debug-misc.conf
+++ b/etc/sysctl.d/40_debug-misc.conf
@@ -25,4 +25,9 @@ fs.suid_dumpable=1
 
 vm.panic_on_oom=0
 
+dev.cdrom.autoclose=1
+dev.cdrom.autoeject=1
+
+dev.cdrom.debug=1
+
 #### meta end


### PR DESCRIPTION
This pull request reverts https://github.com/Kicksecure/security-misc/pull/351.

## Changes

Sets the following `sysctl` settings:
```
dev.cdrom.autoclose=1
dev.cdrom.autoeject=1
dev.cdrom.debug=1
```
## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it